### PR TITLE
Fix toml decode errors.

### DIFF
--- a/meter.toml.example
+++ b/meter.toml.example
@@ -1,5 +1,7 @@
 # example config
 
+host = "https://noj.tw"
+
 [sql]
 url = "sqlite:///database.db"
 connect_args = { check_same_thread = false }
@@ -18,12 +20,9 @@ expire = 60
 server = "msa.hinet.net"
 port = 587
 noreply = "test@gmail.com"
-noreply_password = None
+# noreply_password = "i-am-example-password"
 
 # https://fastapi.tiangolo.com/tutorial/cors/#use-corsmiddleware
 [cors]
 # allow_origins = []
 allow_origin_regex = "http://localhost(:\\d+)?"
-
-
-host = "https://noj.tw"


### PR DESCRIPTION
- #47 
- Move `host` to the top of the config, or it will be considered as a key of `[cors]` section.
- No `None` value in a toml file. Just leave it as a comment.

Close #47 